### PR TITLE
Accessibility Suggestion

### DIFF
--- a/src/components/Hero/HeroStyles.js
+++ b/src/components/Hero/HeroStyles.js
@@ -162,7 +162,7 @@ export const UserInput = styled.input`
     box-shadow: none;
     color: white;
     border-color: white;
-    outline: none;
+    outline-color: transparent;
   }
 
   @media only ${(props) => props.theme.breakpoints.ip} {
@@ -211,7 +211,7 @@ export const SearchSlice = styled.div`
 export const Anchor = styled.a`
   &:focus-visible {
     border: none;
-    outline: none;
+    outline-color: transparent;
   }
 
   &:focus > div {


### PR DESCRIPTION
Small accessibility defect in CSS when using "outline: none" was fixed. Made simple changes following best practices to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc. Reference: https://www.youtube.com/shorts/4B_4WLpbyp8